### PR TITLE
Sanitize Joomla Version

### DIFF
--- a/plugins/system/panopticon/src/Controller/CoreChecksumPrepare.php
+++ b/plugins/system/panopticon/src/Controller/CoreChecksumPrepare.php
@@ -13,8 +13,10 @@ class CoreChecksumPrepare extends AbstractController
 {
 	public function __invoke(\JInput $input): object
 	{
-		$version = JVERSION;
-
+		$version = explode('.', JVERSION);
+		array_walk($version, function(&$v) { $v = (int) $v; });
+		$version = implode('.', $version);
+		
 		$base = trim((string) $input->get('checksumsBaseUrl', '', 'raw'));
 
 		if ($base === '' || !preg_match('#^https?://#i', $base))


### PR DESCRIPTION
Use only core Joomla version, and ignore additions by EOL fixes.

TLWebdesign (https://github.com/TLWebdesign/Joomla-3-EOL-Security-Fixes) continues with unofficial Joomla 3 EOL Security fixes. Those fixes changes JVERSION by adding date of fix to something like this: "3.10.12-2025-01-08-EOLfix". When running Core file integrity check, checksum can't be downloaded from getpanopticon.com, exception is displayed (correctly), and no files are checked at all.

This patch just sanitize the JVERSION constant to only numbers, so "3.10.12-2025-01-08-EOLfix" is changed to "3.10.12", which downloads the checksum and compare files. It shows (of course) files modified by the patch, but still checks all other files, so detecting posssibly corrupted files is much simpler. I know those patches are unofficial, but this small change could make old Joomla 3 instances (still a lot of those around) bit easier repairable.

Thanks for considering this,

Pavel