### PR TITLE
Sanitize uploaded filename extension

### DIFF
--- a/plugins/system/panopticon/src/Controller/ExtensionInstall.php
+++ b/plugins/system/panopticon/src/Controller/ExtensionInstall.php
@@ -216,7 +216,9 @@ class ExtensionInstall extends AbstractController
 		if (empty($extension))
 		{
 			$extension = '.zip';
-		} else {
+		} 
+		else 
+		{
 			// Remove randomized part of the extension
 			$extension = explode('-', $extension)[0];
 		}

--- a/plugins/system/panopticon/src/Controller/ExtensionInstall.php
+++ b/plugins/system/panopticon/src/Controller/ExtensionInstall.php
@@ -216,6 +216,9 @@ class ExtensionInstall extends AbstractController
 		if (empty($extension))
 		{
 			$extension = '.zip';
+		} else {
+			// Remove randomized part of the extension
+			$extension = explode('-', $extension)[0];
 		}
 
 		return $basename . $extension;


### PR DESCRIPTION
Using Panopticon to batch install extension on Joomla 3 sites using file upload always fails.

Test instructions: 
- open Panopticon
- use Install extensions
- select Joomla 3 site
- use option "Extension package file" to select package from your computer
- run the task

Expected result
- extension is installed on site

Actual result
- Extension is not installed, summary email shows error "Failed to unpack the extension package."

Reason:
- Connector plugin uses JInstallerHelper::unpack to unpack the archive, which uses Joomla\Archive\Archive::extract. This function is heavily dependent on filename extension provided, when unknown extension is provided, extraction fails. 
- Panopticon adds random string to uploaded package filename, so filename provided looks something like this `/tmpdir/package.zip-fbd62ea5`
- extension of such file is `zip-fbd62ea5` - unkown to Archive::extract - so the extraction fails.

This PR is trying to solve it by removing anything after the `-` character from the file extension. It could remove some real extension part, however, as Archive::extract supports only zip, tar, tgz, gz, gzip, tbz2, bz2 and bzip2 extensions, it would either end in failure, if the original extension contains `-` character.

Thank you for considering this PR,

Pavel